### PR TITLE
Allow realname to be changed for clients that save state.

### DIFF
--- a/src/components/CustomWelcome.vue
+++ b/src/components/CustomWelcome.vue
@@ -215,6 +215,9 @@ export default {
             if (net) {
                 net.nick = this.nick;
                 net.connection.password = this.password;
+                // Allow gecos to be changed if client saves its state,
+                // otherwise user has to forget network to update. 
+                net.gecos = this.buildGecos();
             }
 
             // If the network doesn't already exist, add a new one


### PR DESCRIPTION
The gecos can not be updated by users that have connected to a network with previous information, if the hosted kiwi client allows the state to be saved to where the network already exists.

This is a simple fix to allow the gecos to update.